### PR TITLE
Add support for Rails >= 3.1

### DIFF
--- a/jquery_mobile_rails.gemspec
+++ b/jquery_mobile_rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 3.1.0"
+  s.add_dependency "rails", ">= 3.1.0"
 
   s.add_development_dependency "sqlite3"
   s.require_path = 'lib'


### PR DESCRIPTION
Currently the dependency only allows Rails 3.1.x
