### PR TITLE
Fix gem require

### DIFF
--- a/jquery_mobile_rails.gemspec
+++ b/jquery_mobile_rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 3.1.0"
+  s.add_dependency "railties", ">= 3.1.0"
 
   s.add_development_dependency "sqlite3"
   s.require_path = 'lib'

--- a/lib/jquery_mobile_rails/version.rb
+++ b/lib/jquery_mobile_rails/version.rb
@@ -1,3 +1,3 @@
 module JqueryMobileRails
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
Replace gem dependency of 'rails' with 'railties' to reflect the modern rails-disaggregated approach. In installations where ActiveRecord isn't used and an alternative ORM/ODM is used (e.g. mongomapper/mongoid/datamapper), 'rails' is only required by this gem - a little unnecessary and heavy.

See for example jquery-fileupload-rails (https://github.com/tors/jquery-fileupload-rails/blob/master/jquery-fileupload-rails.gemspec#L21)
